### PR TITLE
Bugfix: Change chat links target to "_blank"

### DIFF
--- a/src/frojs.chat.js
+++ b/src/frojs.chat.js
@@ -55,7 +55,7 @@ define(['fro'], function(fro) {
 
         // I forget where this regex came from, please don't ask...
         var exp = /(\bhttps?:\&#x2F;\&#x2F;[-A-Z0-9+&@#\&#x2F;%?=~_|!:,.;]*[-A-Z0-9+&@#\&#x2F;%=~_|])/ig;
-        message = message.trim().replace(exp, '<a href="$1" target="_BLANK">$1</a>');
+        message = message.trim().replace(exp, '<a href="$1" target="_blank">$1</a>');
 
         // Stupid *chan shit
         if (message.indexOf('&gt;') === 0) {


### PR DESCRIPTION
Fixes bug in Chrome where `_BLANK` causes links in chat to recycle the same new tab/window, instead of opening new tabs/window for each link click
